### PR TITLE
Library upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+.idea

--- a/README.md
+++ b/README.md
@@ -36,12 +36,10 @@ export interface Foo {
 }
 ```
 
-_typemallow_ even supports Nested Schema fields!
+_typemallow_ supports Nested Schema fields, as well as List and Dict fields!
 
 _main.py_
 ```python
-from typemallow import ts_interface, generate_ts
-
 @ts_interface()
 class Foo(Schema):
     some_field = fields.Str()
@@ -52,6 +50,8 @@ class Bar(Schema):
     foo = fields.Nested(Foo)
     foos = fields.Nested(Foo, many=True)
     bar_field = fields.Str()
+    baz_list = fields.List(fields.Str())
+    baz_dict = fields.Dict(keys=fields.Str(), values=fields.Integer()
 ```
 _output.ts_
 ```typescript
@@ -64,11 +64,38 @@ export interface Bar {
     foo: Foo;
     foos: Foo[];
     bar_field: string;
+    baz_list: string[];
+    baz_dict: [key: string]: number;
+}
+```
+
+_typemallow_ is able to generate enums for schemas that have `OneOf` validation
+
+_main.py_
+```python
+choices = ['foo', 'bar', 'baz']
+
+@ts_interface()
+class TestSchema(Schema):
+    string_field = fields.String(required=True, allow_none=True)
+    enum_field = fields.String(validate=OneOf(choices=choices))
+```
+_output.ts_
+```typescript
+export enum EnumField {
+  FOO = 'foo',
+  BAR = 'bar',
+  BAZ = 'baz'
+}
+
+export interface TestSchema {
+    enum_field?: EnumField;
+    string_field: string| null;
 }
 ```
 
 ### Extended Usage:
-The `@ts_interface()` decorator function accepts an optional parameter, _context_, which defaults to... well... 'default'.
+The `@ts_interface()` decorator function accepts an optional parameter, _context_, which defaults to... well... 'default'. This argument can also be a list of strings.
 
 "_Why is this the case?_" 
 

--- a/test_typemallow.py
+++ b/test_typemallow.py
@@ -1,0 +1,83 @@
+import unittest
+
+from marshmallow import Schema, fields
+from marshmallow.validate import OneOf
+
+import typemallow
+
+class TestTypemallow(unittest.TestCase):
+    def test_snake_to_pascal_case(self):
+        res = typemallow._snake_to_pascal_case('test_key')
+        self.assertEquals(res, 'TestKey')
+
+    def test_get_ts_type_string(self):
+        res = typemallow._get_ts_type(fields.String())
+        self.assertEquals(res, 'string')
+
+    def test_get_ts_type_nested(self):
+        class InternalSchema(Schema):
+            stringField = fields.String()
+
+        res = typemallow._get_ts_type(fields.Nested(InternalSchema))
+
+        self.assertEquals(res, 'InternalSchema')
+
+    def test_get_ts_type_nested_array(self):
+        class InternalSchema(Schema):
+            stringField = fields.String()
+
+        res = typemallow._get_ts_type(fields.Nested(InternalSchema, many=True))
+
+        self.assertEquals(res, 'InternalSchema[]')
+
+    def test_get_ts_type_list(self):
+        res = typemallow._get_ts_type(fields.List(fields.String(), required=False))
+
+        self.assertEquals(res, 'string[]')
+
+    def test_get_ts_type_list_of_nested(self):
+        class InternalSchema(Schema):
+            stringField = fields.String()
+
+        res = typemallow._get_ts_type(fields.List(fields.Nested(InternalSchema)))
+
+        self.assertEquals(res, 'InternalSchema[]')
+
+    def test_get_ts_type_dict(self):
+        res = typemallow._get_ts_type(fields.Dict(keys=fields.String(), values=fields.Integer()))
+
+        self.assertEquals(res, '{[key: string]: number}')
+
+    def test_get_ts_interface_not_stripped(self):
+        choices = ['lorem', 'ipsum', 'dolor']
+
+        class TestSchema(Schema):
+            string_field = fields.String(required=True, allow_none=True)
+            enum_field = fields.String(validate=OneOf(choices=choices))
+
+        res = typemallow._get_ts_interface(TestSchema)
+
+        self.assertEquals(res,
+'''export interface TestSchema {
+\tenum_field?: EnumField;
+\tstring_field: string| null;
+}
+
+''')
+
+    def test_get_ts_interface_stripped(self):
+        choices = ['lorem', 'ipsum', 'dolor']
+
+        class TestSchema(Schema):
+            string_field = fields.String(required=True, allow_none=True)
+            enum_field = fields.String(validate=OneOf(choices=choices))
+
+        res = typemallow._get_ts_interface(TestSchema, strip_schema_keyword=True)
+
+        self.assertEquals(res,
+'''export interface Test {
+\tenum_field?: EnumField;
+\tstring_field: string| null;
+}
+
+''')

--- a/typemallow/__init__.py
+++ b/typemallow/__init__.py
@@ -1,7 +1,8 @@
-from marshmallow import Schema, fields
+from marshmallow import Schema, fields, validate
 from .mappings import mappings
 
 __schemas = dict()
+__enums = dict()
 
 def ts_interface(context='default'):
     '''
@@ -17,17 +18,60 @@ def ts_interface(context='default'):
     class Foo(Schema):
         first_field = fields.Integer()
 
+    'context' can also be a list of strings, in this case the schema will be added to multiple contexts
+
+    e.g.
+    @ts_interface(context=['internal', 'external'])
+    class Foo(Schema):
+        first_field = fields.Integer()
     '''
     def decorator(cls):
         if issubclass(cls, Schema):
-            if not context in __schemas:
-                __schemas[context] = []
-            __schemas[context].append(cls)
+            if isinstance(context, list):
+                for ctx in context:
+                    if not ctx in __schemas:
+                        __schemas[ctx] = []
+                    __schemas[ctx].append(cls)
+            else:
+                if not context in __schemas:
+                    __schemas[context] = []
+                __schemas[context].append(cls)
         return cls
+
     return decorator
 
 
-def __get_ts_interface(schema):
+def _snake_to_pascal_case(key):
+    '''
+    Converts snake_case strings to PascalCase
+    '''
+    return ''.join(s for s in key.replace('_', ' ').title() if not s.isspace())
+
+
+def _get_ts_type(value):
+    if type(value) is fields.Nested:
+        ts_type = value.nested.__name__
+        if value.many:
+            ts_type += '[]'
+    elif type(value) is fields.List:
+        item_type = value.container.__class__
+        if item_type is fields.Nested:
+            nested_type = value.container.nested.__name__
+            ts_type = f'{nested_type}[]'
+        else:
+            type = mappings.get(item_type, 'any')
+            ts_type = f'{type}[]'
+    elif type(value) is fields.Dict:
+        keys_type = mappings.get(type(value.key_container), 'any')
+        values_type = _get_ts_type(value.value_container)
+        ts_type = f'{{[key: {keys_type}]: {values_type}}}'
+    else:
+        ts_type = mappings.get(type(value), 'any')
+
+    return ts_type
+
+
+def _get_ts_interface(schema, context='default', strip_schema_keyword=False):
     '''
 
     Generates and returns a Typescript Interface by iterating
@@ -36,24 +80,58 @@ def __get_ts_interface(schema):
     data type.
 
     '''
-    name = schema.__name__.replace('Schema', '')
+    name = schema.__name__
+    if strip_schema_keyword:
+        name = name.replace('Schema', '')
+
     ts_fields = []
+
     for key, value in schema._declared_fields.items():
-        if type(value) is fields.Nested:
-            ts_type = value.nested.__name__.replace('Schema', '')
-            if value.many:
-                ts_type += '[]'
+        if value.validate and type(value.validate) is validate.OneOf:
+            # add to enums to be exported with _generate_enums_exports
+            __enums[context] = {}
+            __enums[context][_snake_to_pascal_case(key)] = value.validate.choices
+            ts_type = _snake_to_pascal_case(key)
         else:
-            ts_type = mappings.get(type(value), 'any')
+            ts_type = _get_ts_type(value)
+
+        if value.allow_none:
+            ts_type += '| null'
+
+        if not value.required:
+            key += '?'
 
         ts_fields.append(
             f'\t{key}: {ts_type};'
         )
+
     ts_fields = '\n'.join(ts_fields)
     return f'export interface {name} {{\n{ts_fields}\n}}\n\n'
 
 
-def generate_ts(output_path, context='default'):
+def _generate_enums_exports(context='default'):
+    '''
+    Generates export statements for each enum found in schemas' with 'oneof' validations
+    '''
+    enum_exports = []
+    for key, choices_tuple in __enums[context].iteritems():
+        enum_fields = []
+        for choice in choices_tuple:
+            enum_fields.append(
+                f'\t{choice.upper()} = "{choice}",'
+            )
+        enum_fields = '\n'.join(enum_fields)
+        enum_exports.append(
+            f'export enum {key} {{\n{enum_fields}\n}}'
+        )
+
+    if (len(enum_exports) > 0):
+        return f'{enum_exports}\n\n'
+    else:
+        return ''
+
+
+def generate_ts(output_path, context='default', strip_schema_keyword=False):
     '''
 
     When this function is called, a Typescript interface will be generated
@@ -64,7 +142,10 @@ def generate_ts(output_path, context='default'):
     
     The Typescript interfaces will then be outputted to the file provided.
 
+    The output file will also contain any enums found while iterating over the schemas.
+
     '''
     with open(output_path, 'w') as output_file:
-        interfaces = [__get_ts_interface(schema) for schema in __schemas[context]]
+        interfaces = [_get_ts_interface(schema, context, strip_schema_keyword) for schema in __schemas[context]]
+        output_file.write(''.join(_generate_enums_exports(context)))
         output_file.write(''.join(interfaces))

--- a/typemallow/mappings.py
+++ b/typemallow/mappings.py
@@ -23,6 +23,5 @@ mappings = {
     fields.String: 'string',
     fields.TimeDelta: 'any',
     fields.Url: 'string',
-    fields.Url: 'string',
     fields.UUID: 'string',
 }


### PR DESCRIPTION
Used this library on a project and decided to expand upon it.

- allow for context to be a list of strings for cases where you need access to a type across multiple generated files
- optionally strip the word 'Schema' from the resulting TS interface
- generate enums from the `choices` for schemas with `OneOf` validation
- generate more detailed types for `List` and `Dict` fields